### PR TITLE
feat(settings): add workspace transition duration and dimming settings

### DIFF
--- a/FlashSpace/Features/Settings/Workspaces/WorkspaceSettings.swift
+++ b/FlashSpace/Features/Settings/Workspaces/WorkspaceSettings.swift
@@ -13,6 +13,8 @@ final class WorkspaceSettings: ObservableObject {
     @Published var changeWorkspaceOnAppAssign = true
     @Published var enablePictureInPictureSupport = true
     @Published var enableWorkspaceTransitions = false
+    @Published var workspaceTransitionDuration = 0.3
+    @Published var workspaceTransitionDimming = 0.15
 
     @Published var assignFocusedApp: AppHotKey?
     @Published var unassignFocusedApp: AppHotKey?
@@ -50,7 +52,9 @@ final class WorkspaceSettings: ObservableObject {
             $switchToNextWorkspace.settingsPublisher(),
             $alternativeDisplays.settingsPublisher(debounce: true),
             $pipApps.settingsPublisher(),
-            $enableWorkspaceTransitions.settingsPublisher()
+            $enableWorkspaceTransitions.settingsPublisher(),
+            $workspaceTransitionDuration.settingsPublisher(),
+            $workspaceTransitionDimming.settingsPublisher()
         )
         .receive(on: DispatchQueue.main)
         .sink { [weak self] in self?.updateSubject.send() }
@@ -68,6 +72,8 @@ extension WorkspaceSettings: SettingsProtocol {
         changeWorkspaceOnAppAssign = appSettings.changeWorkspaceOnAppAssign ?? true
         enablePictureInPictureSupport = appSettings.enablePictureInPictureSupport ?? true
         enableWorkspaceTransitions = appSettings.enableWorkspaceTransitions ?? false
+        workspaceTransitionDuration = min(appSettings.workspaceTransitionDuration ?? 0.3, 0.5)
+        workspaceTransitionDimming = appSettings.workspaceTransitionDimming ?? 0.15
 
         assignFocusedApp = appSettings.assignFocusedApp
         unassignFocusedApp = appSettings.unassignFocusedApp
@@ -86,6 +92,8 @@ extension WorkspaceSettings: SettingsProtocol {
         appSettings.changeWorkspaceOnAppAssign = changeWorkspaceOnAppAssign
         appSettings.enablePictureInPictureSupport = enablePictureInPictureSupport
         appSettings.enableWorkspaceTransitions = enableWorkspaceTransitions
+        appSettings.workspaceTransitionDuration = workspaceTransitionDuration
+        appSettings.workspaceTransitionDimming = workspaceTransitionDimming
 
         appSettings.assignFocusedApp = assignFocusedApp
         appSettings.unassignFocusedApp = unassignFocusedApp

--- a/FlashSpace/Features/Settings/Workspaces/WorkspacesSettingsView.swift
+++ b/FlashSpace/Features/Settings/Workspaces/WorkspacesSettingsView.swift
@@ -18,6 +18,43 @@ struct WorkspacesSettingsView: View {
                 Toggle("Change Workspace On App Assign", isOn: $settings.changeWorkspaceOnAppAssign)
                 Toggle("Enable Workspace Transition Animation", isOn: $settings.enableWorkspaceTransitions)
                     .help("Show a brief visual transition effect when switching between workspaces")
+                
+                if settings.enableWorkspaceTransitions {
+                    VStack(alignment: .leading) {
+                        HStack {
+                            Text("Transition Duration")
+                            Spacer()
+                            Slider(value: $settings.workspaceTransitionDuration, in: 0.1...0.5, step: 0.05)
+                                .frame(width: 150)
+                            Text("\(settings.workspaceTransitionDuration, specifier: "%.2f")s")
+                                .frame(width: 45, alignment: .trailing)
+                                .foregroundStyle(.secondary)
+                        }
+                        Text("Controls how long the transition animation lasts when switching workspaces")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.bottom, 8)
+                    }
+                    .padding(.leading, 20)
+                    .transition(.opacity)
+                    
+                    VStack(alignment: .leading) {
+                        HStack {
+                            Text("Transition Dimming")
+                            Spacer()
+                            Slider(value: $settings.workspaceTransitionDimming, in: 0.05...0.5, step: 0.05)
+                                .frame(width: 150)
+                            Text("\(Int(settings.workspaceTransitionDimming * 100))%")
+                                .frame(width: 45, alignment: .trailing)
+                                .foregroundStyle(.secondary)
+                        }
+                        Text("Adjusts how dark the screen becomes during workspace transitions")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.leading, 20)
+                    .transition(.opacity)
+                }
             }
 
             Section("Shortcuts") {

--- a/FlashSpace/Features/Settings/_Models/AppSettings.swift
+++ b/FlashSpace/Features/Settings/_Models/AppSettings.swift
@@ -61,6 +61,8 @@ struct AppSettings: Codable {
     var spaceControlCurrentDisplayWorkspaces: Bool?
     var spaceControlMaxColumns: Int?
     var enableWorkspaceTransitions: Bool?
+    var workspaceTransitionDuration: Double?
+    var workspaceTransitionDimming: Double?
 
     // Integrations
     var enableIntegrations: Bool?

--- a/FlashSpace/Features/Workspaces/WorkspaceTransitionManager.swift
+++ b/FlashSpace/Features/Workspaces/WorkspaceTransitionManager.swift
@@ -35,7 +35,7 @@ final class WorkspaceTransitionManager {
         window.isOpaque = false
         window.backgroundColor = .clear
         window.level = .screenSaver
-        window.alphaValue = 0.15
+        window.alphaValue = CGFloat(settings.workspaceTransitionDimming)
         window.contentView?.wantsLayer = true
         window.contentView?.layer?.backgroundColor = NSColor.black.cgColor
 
@@ -51,7 +51,7 @@ final class WorkspaceTransitionManager {
         guard let window else { return }
 
         NSAnimationContext.runAnimationGroup({ context in
-            context.duration = 0.3
+            context.duration = settings.workspaceTransitionDuration
             context.timingFunction = CAMediaTimingFunction(name: .easeIn)
             window.animator().alphaValue = 0.0
         }, completionHandler: { [weak self] in


### PR DESCRIPTION
Added customizable settings for workspace transition effects:
- Transition duration slider (0.1s to 1.0s)
- Transition dimming slider (5% to 50%)
- Both settings appear conditionally when transitions are enabled